### PR TITLE
Remove spring-boot-maven-plugin from Tomcat sample.

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -75,7 +75,7 @@
                             <outputDirectory>${basedir}/target/classes/public</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>src/main/todo/build</directory>
+                                    <directory>${project.basedir}/src/main/todo/build</directory>
                                 </resource>
                             </resources>
                         </configuration>
@@ -129,7 +129,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <workingDirectory>src/main/todo</workingDirectory>
+                    <workingDirectory>${project.basedir}/src/main/todo</workingDirectory>
                     <nodeVersion>${version.node}</nodeVersion>
                 </configuration>
             </plugin>

--- a/spring-boot/src/main/resources/application.properties
+++ b/spring-boot/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=Todo
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/todoapp_db
-spring.datasource.username=postgres
-spring.datasource.password=admin
+spring.datasource.url=${POSTGRESQL_DB_URL:jdbc:postgresql://localhost:5432/todoapp_db}
+spring.datasource.username=${POSTGRESQL_DB_USER:postgres}
+spring.datasource.password=${POSTGRESQL_DB_PASSWORD:admin}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.hibernate.ddl-auto=none

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -6,7 +6,7 @@ ENV CATALINA_HOME=/usr/local/tomcat
 ENV DEPLOY_DIR=$CATALINA_HOME/webapps
 
 # Copy the WAR file to the Tomcat webapps directory
-COPY target/todo.war $DEPLOY_DIR/
+COPY target/ROOT.war $DEPLOY_DIR/
 
 # Expose the default Tomcat port
 EXPOSE 8080

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Tomcat base image
-FROM tomcat:11.0-jdk17
+FROM tomcat:10.1-jdk17
 
 # Set environment variables
 ENV CATALINA_HOME=/usr/local/tomcat

--- a/tomcat/pom.xml
+++ b/tomcat/pom.xml
@@ -21,6 +21,7 @@
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
+        <version.war.plugin>3.4.0</version.war.plugin>
         <version.maven.resources.plugin>3.3.1</version.maven.resources.plugin>
         <version.frontend.maven.plugin>1.15.1</version.frontend.maven.plugin>
         <version.node>v20.17.0</version.node>
@@ -69,28 +70,6 @@
                 <version>${version.compiler.plugin}</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>${version.maven.resources.plugin}</version>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/classes/public</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>src/main/todo/build</directory>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>${version.frontend.maven.plugin}</version>
@@ -137,13 +116,21 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <workingDirectory>src/main/todo</workingDirectory>
+                    <workingDirectory>${project.basedir}/src/main/todo</workingDirectory>
                     <nodeVersion>${version.node}</nodeVersion>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${version.war.plugin}</version>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <directory>${project.basedir}/src/main/todo/build</directory>
+                        </resource>
+                    </webResources>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tomcat/pom.xml
+++ b/tomcat/pom.xml
@@ -61,7 +61,8 @@
     </dependencies>
 
     <build>
-        <finalName>todo</finalName>
+        <!-- App Service deploys the app to root. The final name make sure the app is deployed to root in local development.-->
+        <finalName>ROOT</finalName>
 
         <plugins>
             <plugin>

--- a/tomcat/src/main/resources/application.properties
+++ b/tomcat/src/main/resources/application.properties
@@ -2,9 +2,9 @@ spring.application.name=Todo
 
 spring.jpa.properties.hibernate.transaction.coordinator_class=jdbc
 
-spring.datasource.url=jdbc:postgresql://postgres:5432/todoapp_db
-spring.datasource.username=postgres
-spring.datasource.password=admin
+spring.datasource.url=${POSTGRESQL_DB_URL:jdbc:postgresql://postgres:5432/todoapp_db}
+spring.datasource.username=${POSTGRESQL_DB_USER:postgres}
+spring.datasource.password=${POSTGRESQL_DB_PASSWORD:admin}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.hibernate.ddl-auto=none
@@ -15,4 +15,4 @@ spring.jpa.properties.jakarta.persistence.schema-generation.scripts.create-targe
 spring.jpa.properties.jakarta.persistence.schema-generation.scripts.create-source=metadata
 spring.jpa.properties.jakarta.persistence.schema-generation.scripts.drop-target=scripts/drop.sql
 
-logging.level.org.hibernate=DEBUG
+# logging.level.org.hibernate=DEBUG

--- a/tomcat/src/main/todo/package.json
+++ b/tomcat/src/main/todo/package.json
@@ -12,7 +12,6 @@
     "react-toastify": "^11.0.2"
   },
   "proxy": "http://localhost:8080",
-  "homepage": "/todo",
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",

--- a/tomcat/src/main/todo/src/App.css
+++ b/tomcat/src/main/todo/src/App.css
@@ -73,7 +73,7 @@ li {
   height: 16px;
   opacity: 0.5;
   width: 23px;
-  background-image: url('/todo/remove.png'); /* Replace with your image path */
+  background-image: url('/remove.png'); /* Replace with your image path */
   background-size: cover;
 }
 


### PR DESCRIPTION
This pull request includes updates to the `spring-boot` and `tomcat` projects' `pom.xml` files to improve consistency and configuration management. The most important changes include updating directory paths to use project base directory variables and modifying plugin configurations.

Updates to directory paths:

* [`spring-boot/pom.xml`](diffhunk://#diff-107ca807a36bf4b8d6915cd626e51027067468ab5bde96316682ae9bbc6f973bL78-R78): Changed the `directory` and `workingDirectory` paths to use `${project.basedir}` for better consistency and flexibility. [[1]](diffhunk://#diff-107ca807a36bf4b8d6915cd626e51027067468ab5bde96316682ae9bbc6f973bL78-R78) [[2]](diffhunk://#diff-107ca807a36bf4b8d6915cd626e51027067468ab5bde96316682ae9bbc6f973bL132-R132)
* [`tomcat/pom.xml`](diffhunk://#diff-e2712ba9c2992cca6dbf4b9808bcd56985b913359925d036707ade690b1c1212L140-R133): Updated the `workingDirectory` path to use `${project.basedir}` for consistency.

Plugin configuration changes:

* [`tomcat/pom.xml`](diffhunk://#diff-e2712ba9c2992cca6dbf4b9808bcd56985b913359925d036707ade690b1c1212R24): Added the `version.war.plugin` property to specify the version of the `maven-war-plugin`.
* [`tomcat/pom.xml`](diffhunk://#diff-e2712ba9c2992cca6dbf4b9808bcd56985b913359925d036707ade690b1c1212L71-L92): Removed the `maven-resources-plugin` configuration to simplify the build process.
* [`tomcat/pom.xml`](diffhunk://#diff-e2712ba9c2992cca6dbf4b9808bcd56985b913359925d036707ade690b1c1212L140-R133): Replaced the `spring-boot-maven-plugin` with the `maven-war-plugin` and added configuration for web resources.