### PR TITLE
Enable health check in Spring Boot application.

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -1,2 +1,21 @@
 # JavaScript/React Front-End
 This is the shared JavaScript/React front-end for the Java applications.
+
+## Run the frontend locally
+
+Start json-server with:
+
+```
+npm run json-server
+```
+
+The fake data can be access via `http://localhost:3001/todos`
+
+Start the React application:
+
+```
+export NODE_OPTIONS=--openssl-legacy-provider
+npm start
+```
+
+Access the frontend with `http://localhost:3000`

--- a/react/package.json
+++ b/react/package.json
@@ -15,7 +15,8 @@
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "json-server": "json-server --watch src/json-server/Todos.json --port 3001"
   },
   "eslintConfig": {
     "extends": [
@@ -34,5 +35,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "json-server": "^1.0.0-beta.3"
   }
 }

--- a/react/src/config/BackendConfig.js
+++ b/react/src/config/BackendConfig.js
@@ -1,0 +1,10 @@
+const devConfig = {
+    API_URL: 'http://localhost:3001/todos'
+};
+
+const prodConfig = {
+    API_URL: '/resources/todo'
+};
+
+const config = process.env.NODE_ENV === 'development' ? devConfig : prodConfig;
+export default config;

--- a/react/src/json-server/Todos.json
+++ b/react/src/json-server/Todos.json
@@ -1,0 +1,6 @@
+{
+    "todos": [
+      { "id": 1, "description": "Buy milk", "completed": false },
+      { "id": 2, "description": "Walk the dog", "completed": true }
+    ]
+  }

--- a/react/src/utils/ToDoService.js
+++ b/react/src/utils/ToDoService.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import config from '../config/BackendConfig';
 
-const API_URL = '/resources/todo';
+const API_URL = config.API_URL;
 
 const ToDoService = {
   getItems: () => {

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -26,7 +26,7 @@
         <version.node>v20.17.0</version.node>
         <version.compiler.plugin>3.13.0</version.compiler.plugin>
         <version.jakarta.cdi>4.1.0</version.jakarta.cdi>
-        <maven.compiler.release>17</maven.compiler.release>        
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -40,6 +40,11 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <version>${version.jakarta.cdi}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
         <!-- Spring Data support for persistence -->
@@ -156,8 +161,8 @@
                     <webContainer>Java SE</webContainer>
                     <appSettings>
                         <property>
-	                        <name>WEBSITE_SKIP_AUTOCONFIGURE_DATABASE</name>
-	                        <value>true</value>
+                            <name>WEBSITE_SKIP_AUTOCONFIGURE_DATABASE</name>
+                            <value>true</value>
                         </property>
                     </appSettings>
                     <deployment>

--- a/spring-boot/src/main/resources/application.properties
+++ b/spring-boot/src/main/resources/application.properties
@@ -7,3 +7,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.properties.jakarta.persistence.schema-generation.database.action=drop-and-create
 spring.jpa.show-sql=true
+
+management.endpoint.health.enabled=true
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=always


### PR DESCRIPTION
This pull request includes significant changes to the JavaScript/React front-end and minor updates to the Spring Boot backend configuration. The most important changes include adding local development support for the React application, configuring a mock backend with `json-server`, and updating the Spring Boot configuration to include health management endpoints.

### JavaScript/React Front-End:

* [`react/README.md`](diffhunk://#diff-dbd8999c1b6d2e969e3d8fbdce0b705d0f72158e344900d3a4fb29b0a3b18bebR3-R21): Added instructions for running the frontend locally, including starting `json-server` and the React application.
* [`react/package.json`](diffhunk://#diff-5a3f058f37c9436d08fa97bd30209f67c9a1a61d041b0ce27e48613dfb3a1a10L18-R19): Added a new script to start `json-server` and included `json-server` as a development dependency. [[1]](diffhunk://#diff-5a3f058f37c9436d08fa97bd30209f67c9a1a61d041b0ce27e48613dfb3a1a10L18-R19) [[2]](diffhunk://#diff-5a3f058f37c9436d08fa97bd30209f67c9a1a61d041b0ce27e48613dfb3a1a10R38-R40)
* [`react/src/config/BackendConfig.js`](diffhunk://#diff-9fd908f9515a3ffbf337ced0a3afc3f5234f7d3d50399420bc94186abf2d035eR1-R10): Introduced a configuration file to switch between development and production API URLs.
* [`react/src/json-server/Todos.json`](diffhunk://#diff-9877fff0e843602e2706ca373bb2e653e494740210bb3a026a260364855357e4R1-R6): Created a mock data file for `json-server` to simulate backend responses.
* [`react/src/utils/ToDoService.js`](diffhunk://#diff-f51ec92f3e9fa7ea39d4a99657802d9bf8464b558afc6a1bd70f8fd3f8e476cfR2-R4): Updated the service to use the new configuration for API URLs.

### Spring Boot Backend:

* [`spring-boot/pom.xml`](diffhunk://#diff-107ca807a36bf4b8d6915cd626e51027067468ab5bde96316682ae9bbc6f973bR45-R49): Added the `spring-boot-starter-actuator` dependency to enable application monitoring and management.
* [`spring-boot/src/main/resources/application.properties`](diffhunk://#diff-8f48d438d76299fd5ccc0465b8d0289c3310113abe1d711e0d5500825fbe76abR10-R13): Enabled health management endpoints and configured them to show details.